### PR TITLE
Fix TypeScript build errors for Cloudflare deployment

### DIFF
--- a/src/components/CountryExposure.test.tsx
+++ b/src/components/CountryExposure.test.tsx
@@ -86,13 +86,13 @@ describe('CountryExposure', () => {
 
   it('has HP selected by default', () => {
     render(<CountryExposure />)
-    const selector = screen.getByRole('combobox')
+    const selector = screen.getByRole('combobox') as HTMLSelectElement
     expect(selector.value).toBe('hp')
   })
 
   it('allows company selection', async () => {
     render(<CountryExposure />)
-    const selector = screen.getByRole('combobox')
+    const selector = screen.getByRole('combobox') as HTMLSelectElement
 
     // Change to Apple
     fireEvent.change(selector, { target: { value: 'apple' } })

--- a/src/components/CountryExposure.test.tsx
+++ b/src/components/CountryExposure.test.tsx
@@ -86,19 +86,19 @@ describe('CountryExposure', () => {
 
   it('has HP selected by default', () => {
     render(<CountryExposure />)
-    const selector = screen.getByRole('combobox') as HTMLSelectElement
-    expect(selector.value).toBe('hp')
+    const selector = screen.getByRole('combobox')
+    expect((selector as HTMLSelectElement).value).toBe('hp')
   })
 
   it('allows company selection', async () => {
     render(<CountryExposure />)
-    const selector = screen.getByRole('combobox') as HTMLSelectElement
+    const selector = screen.getByRole('combobox')
 
     // Change to Apple
     fireEvent.change(selector, { target: { value: 'apple' } })
 
     await waitFor(() => {
-      expect(selector.value).toBe('apple')
+      expect((selector as HTMLSelectElement).value).toBe('apple')
     })
   })
 

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -86,7 +86,13 @@ describe('Navigation', () => {
     const { rerender } = render(<Navigation currentView="tariff" onViewChange={mockOnViewChange} />)
 
     // Test each view type
-    const viewTypes: Array<Parameters<typeof Navigation>[0]['currentView']> = ['startup', 'timeline', 'country-timeline', 'exposure', 'notifications']
+    const viewTypes: Parameters<typeof Navigation>[0]['currentView'][] = [
+      'startup',
+      'timeline',
+      'country-timeline',
+      'exposure',
+      'notifications',
+    ]
 
     for (const viewType of viewTypes) {
       mockOnViewChange.mockClear()

--- a/src/components/Navigation.test.tsx
+++ b/src/components/Navigation.test.tsx
@@ -86,7 +86,7 @@ describe('Navigation', () => {
     const { rerender } = render(<Navigation currentView="tariff" onViewChange={mockOnViewChange} />)
 
     // Test each view type
-    const viewTypes = ['startup', 'timeline', 'country-timeline', 'exposure', 'notifications']
+    const viewTypes: Array<Parameters<typeof Navigation>[0]['currentView']> = ['startup', 'timeline', 'country-timeline', 'exposure', 'notifications']
 
     for (const viewType of viewTypes) {
       mockOnViewChange.mockClear()


### PR DESCRIPTION
## Summary

This PR fixes TypeScript compilation errors that were causing the Cloudflare build to fail after PR #3 was merged.

## Problem

The Cloudflare build was failing with:
```
src/components/CountryExposure.test.tsx(90,21): error TS2339: Property 'value' does not exist on type 'HTMLElement'.
src/components/CountryExposure.test.tsx(101,23): error TS2339: Property 'value' does not exist on type 'HTMLElement'.
src/components/Navigation.test.tsx(93,28): error TS2322: Type 'string' is not assignable to type 'ViewType'.
```

## Solution

1. **CountryExposure.test.tsx**: Added proper type casting from HTMLElement to HTMLSelectElement when accessing the `value` property
2. **Navigation.test.tsx**: Fixed the ViewType type issue by properly typing the viewTypes array

## Testing

- ✅ All tests pass (80 tests)
- ✅ `pnpm build` completes successfully
- ✅ TypeScript compilation (`tsc -b`) has no errors

This should resolve the Cloudflare deployment failure.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>